### PR TITLE
note about xAPI 401 unauthorized

### DIFF
--- a/statements.md
+++ b/statements.md
@@ -9,9 +9,18 @@ xAPI Statements
 <a name="basicauth"></a>
 ## Basic Auth
 
-The primary way to submit and retrieve statements from a Learning Locker LRS is via http Basic Authentication. Upon creation each LRS generates a unique key / secret which pair as the username / password. You can reset these values at any time in the LRS setting page. 
+The primary way to submit and retrieve statements from a Learning Locker LRS is via http Basic Authentication. Upon creation each LRS generates a unique key / secret which pair as the username / password. You can reset these values at any time in the LRS setting page.
 
 > It is important to make sure you employ SSL on production sites using basic auth and never share your key / secret
+
+If your get 401 unauthorized requests in your calls to xAPI then It is posible you have some module config striping the Authorization header, usually for
+"security reasons". You can work around this issue by passing the header directly to PHP via the env in your apache default config or your virtual host:
+
+    <VirtualHost *>
+      ...
+      SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+      ...
+    </VirtualHost>
 
 <a name="structure"></a>
 ## Structure


### PR DESCRIPTION
I was having problems to get working xAPI endpoint after migrate from Vaprobash (Vagrant) Ubuntu 12.04 to 14.04 due to 401 unauthorized requests. Debugging I noticed neither PHP_AUTH_USER nor PHP_AUTH_PW are available. Finally googling I found the work around for this setup and I've included a note in statement documentation.

Special thanks to [Rich](http://stackoverflow.com/users/8261/rich) http://stackoverflow.com/questions/17488656/zend-server-windows-authorization-header-is-not-passed-to-php-script have the applied solution 
