### PR TITLE
CentOS 7 installation using Ansible (and Vagrant)

### DIFF
--- a/src/installation.md
+++ b/src/installation.md
@@ -18,6 +18,7 @@ Additional information:
 - [Installation on Ubuntu](http://www.jpablo128.com/how_to_install_learning_locker/) thanks to [@jpablo128](https://twitter.com/jpablo128)
 - [Installation on CentOS 7.0](https://gist.github.com/davidpesce/7d6e1b81594ecbc72311) thanks to [@davidpesce](https://github.com/davidpesce)
 - [Installation on Ubuntu with Vagrant](http://www.jmblog.org/blog/2015/02/03/learning-locker-vagrant) thanks to [Jim Baker](http://www.jmblog.org)
+- [Installation on CentOS 7.0 with Ansible (and optionally Vagrant)](https://github.com/gomezgoiri/learninglocker-centos7) thanks to [@gomezgoiri](https://github.com/gomezgoiri)
 - [Load Balancing](http://learninglocker.net/2015/04/01/load-balancing-learning-locker/)
 
 ## Requirements


### PR DESCRIPTION
Listing an Ansible playbook that I have created to install LearningLocker (with Apache and Mongo) on a CentOS 7 machine (I have also tested it in a RHEL 7).

The playbook is modular so the database and the web server can reside in different machines.

The Github project also includes a Vagrant script with two configurations:
  * LL in one machine.
  * LL in two machines: one for the database and another for the web server.