### PR TITLE
xapi-service now uses yarn for requirements/build

### DIFF
--- a/src/guides-custom-installation.md
+++ b/src/guides-custom-installation.md
@@ -121,14 +121,13 @@ git clone https://github.com/LearningLocker/xapi-service.git
 Enter the directory and install the requirements:
 
 ```
-npm install
+yarn install
 ```
-_Note: we do not currently use `yarn` to install the xAPI Service_
 
 ### Build
 
 ```
-npm run build
+yarn build-all
 ```
 
 ### Configuration

--- a/src/guides-custom-installation.md
+++ b/src/guides-custom-installation.md
@@ -127,7 +127,7 @@ yarn install
 ### Build
 
 ```
-yarn build-all
+yarn build
 ```
 
 ### Configuration


### PR DESCRIPTION
xapi-service can now use yarn for requirements and build. Small tweak to docs to show this.