### PR TITLE
Fix broken persona link

### DIFF
--- a/src/http-persona-identifiers.md
+++ b/src/http-persona-identifiers.md
@@ -17,7 +17,7 @@ Name | Description
 --- | ---
 _id | The id of this identifier.
 organisation | The id of the [organisation](../http-organisations) this identifier belongs to.
-persona | The id of the [persona](../http-persona) this identifier belongs to.
+persona | The id of the [persona](../http-personas) this identifier belongs to.
 ifi | A representation of the [inverse functional identifier](#inverse-functional-identifier).
 
 ### Example


### PR DESCRIPTION
Similar to the other PR. I was getting a 404 clicking on this link, so switched it to `http-personas`, which I believe is the correct one.